### PR TITLE
feat: unified mcp server state for figma,framer and canva

### DIFF
--- a/server/jobs/jobManager.ts
+++ b/server/jobs/jobManager.ts
@@ -1,0 +1,51 @@
+export type JobStatus = "queued" | "running" | "completed" | "failed";
+
+export type JobRecord = {
+  id: string;
+  status: JobStatus;
+  result?: unknown;
+  error?: string;
+};
+
+type Listener = (event: { type: JobStatus; job: JobRecord }) => void;
+
+class JobManager {
+  private jobs = new Map<string, JobRecord>();
+  private listeners = new Map<string, Set<Listener>>();
+
+  create(jobId: string) {
+    const job: JobRecord = { id: jobId, status: "queued" };
+    this.jobs.set(jobId, job);
+    this.emit(jobId, { type: "queued", job });
+    return job;
+  }
+
+  get(jobId: string) {
+    return this.jobs.get(jobId);
+  }
+
+  on(jobId: string, listener: Listener) {
+    if (!this.listeners.has(jobId)) this.listeners.set(jobId, new Set());
+    this.listeners.get(jobId)!.add(listener);
+    return () => this.listeners.get(jobId)!.delete(listener);
+  }
+
+  setStatus(jobId: string, status: JobStatus, data?: { result?: unknown; error?: string }) {
+    const job = this.jobs.get(jobId);
+    if (!job) return;
+    job.status = status;
+    if (data?.result !== undefined) job.result = data.result;
+    if (data?.error) job.error = data.error;
+    this.emit(jobId, { type: status, job });
+  }
+
+  private emit(jobId: string, event: { type: JobStatus; job: JobRecord }) {
+    const set = this.listeners.get(jobId);
+    if (!set) return;
+    for (const listener of set) listener(event);
+  }
+}
+
+export const jobManager = new JobManager();
+
+

--- a/server/mcp/index.ts
+++ b/server/mcp/index.ts
@@ -1,0 +1,11 @@
+import { UnifiedMCPServer } from "./mcp";
+import { FigmaProvider } from "@/server/providers/figmaProvider";
+import { FramerProvider } from "@/server/providers/framerProvider";
+import { CanvaProvider } from "@/server/providers/canvaProvider";
+
+export const mcp = new UnifiedMCPServer();
+mcp.registerProvider("figma", new FigmaProvider());
+mcp.registerProvider("framer", new FramerProvider());
+mcp.registerProvider("canva", new CanvaProvider());
+
+

--- a/server/mcp/mcp.ts
+++ b/server/mcp/mcp.ts
@@ -1,0 +1,39 @@
+export type MCPTask = {
+  id: string;
+  provider: "figma" | "framer" | "canva" | "unknown";
+  action: string;
+  payload: Record<string, unknown>;
+};
+
+export type MCPResult = {
+  taskId: string;
+  status: "queued" | "running" | "completed" | "failed";
+  data?: unknown;
+  error?: string;
+};
+
+export interface MCPProvider {
+  runTask(task: MCPTask): Promise<MCPResult>;
+}
+
+export class UnifiedMCPServer {
+  private providers: Record<string, MCPProvider> = {};
+
+  registerProvider(name: string, provider: MCPProvider) {
+    this.providers[name] = provider;
+  }
+
+  async execute(task: MCPTask): Promise<MCPResult> {
+    const provider = this.providers[task.provider];
+    if (!provider) {
+      return {
+        taskId: task.id,
+        status: "failed",
+        error: `No provider registered for ${task.provider}`,
+      };
+    }
+    return provider.runTask(task);
+  }
+}
+
+

--- a/server/orchestrator/orchestrator.ts
+++ b/server/orchestrator/orchestrator.ts
@@ -1,0 +1,61 @@
+import { jobManager } from "@/server/jobs/jobManager";
+import { mcp } from "@/server/mcp";
+
+export type OrchestratorState = {
+  taskId: string;
+  prompt: string;
+  steps: Array<{ tool: string; params: Record<string, unknown> }>;
+  executedSteps: Array<{ tool: string; params: Record<string, unknown>; result?: unknown }>;
+  finalMessage: string | null;
+};
+
+function planStepsFromPrompt(prompt: string) {
+  // Placeholder planner: map a generic button prompt to 3 steps
+  // In production, replace with an LLM planning call
+  return [
+    { tool: "figma.createRectangle", params: { width: 200, height: 50, color: "#3B82F6" } },
+    { tool: "figma.createText", params: { content: "Sign Up", fontSize: 18 } },
+    { tool: "figma.groupElements", params: { elementIds: ["rect-id", "text-id"] } },
+  ];
+}
+
+export async function runOrchestration(opts: { taskId: string; prompt: string; fileId: string; platform: "figma" | "framer" | "canva"; accessToken?: string }) {
+  const { taskId, prompt, fileId, platform } = opts;
+  const state: OrchestratorState = {
+    taskId,
+    prompt,
+    steps: [],
+    executedSteps: [],
+    finalMessage: null,
+  };
+
+  // Node 1: Planner
+  state.steps = planStepsFromPrompt(prompt);
+  jobManager.setStatus(taskId, "running", { result: { message: "Plan created. Starting execution." } });
+
+  // Node 2: Tool Executor Loop
+  for (let i = 0; i < state.steps.length; i++) {
+    const step = state.steps[i];
+    try {
+      const action = step.tool.replace(/^.*?\./, "");
+      const res = await mcp.execute({
+        id: `${taskId}:${i}`,
+        provider: platform,
+        action,
+        payload: { fileId, ...step.params },
+      });
+      if (res.status !== "completed") throw new Error(res.error || "Step failed");
+      state.executedSteps.push({ ...step, result: res.data });
+      jobManager.setStatus(taskId, "running", { result: { message: `Step ${i + 1}/${state.steps.length} completed: ${step.tool}` } });
+    } catch (err) {
+      jobManager.setStatus(taskId, "failed", { error: (err as Error).message });
+      return;
+    }
+  }
+
+  // Node 3: Finalizer
+  state.finalMessage = "All done! Your design is ready.";
+  jobManager.setStatus(taskId, "completed", { result: { message: state.finalMessage } });
+}
+
+

--- a/server/providers/canvaProvider.ts
+++ b/server/providers/canvaProvider.ts
@@ -1,0 +1,13 @@
+import type { MCPProvider, MCPResult, MCPTask } from "@/server/mcp/mcp";
+
+export class CanvaProvider implements MCPProvider {
+  async runTask(task: MCPTask): Promise<MCPResult> {
+    return {
+      taskId: task.id,
+      status: "completed",
+      data: { message: "Canva task stub executed", action: task.action },
+    };
+  }
+}
+
+

--- a/server/providers/figmaProvider.ts
+++ b/server/providers/figmaProvider.ts
@@ -1,0 +1,14 @@
+import type { MCPProvider, MCPResult, MCPTask } from "@/server/mcp/mcp";
+
+export class FigmaProvider implements MCPProvider {
+  async runTask(task: MCPTask): Promise<MCPResult> {
+    // Placeholder: integrate Figma REST API here using user's OAuth token
+    return {
+      taskId: task.id,
+      status: "completed",
+      data: { message: "Figma task stub executed", action: task.action },
+    };
+  }
+}
+
+

--- a/server/providers/framerProvider.ts
+++ b/server/providers/framerProvider.ts
@@ -1,0 +1,13 @@
+import type { MCPProvider, MCPResult, MCPTask } from "@/server/mcp/mcp";
+
+export class FramerProvider implements MCPProvider {
+  async runTask(task: MCPTask): Promise<MCPResult> {
+    return {
+      taskId: task.id,
+      status: "completed",
+      data: { message: "Framer task stub executed", action: task.action },
+    };
+  }
+}
+
+

--- a/server/trpc/context.ts
+++ b/server/trpc/context.ts
@@ -1,0 +1,17 @@
+import type { inferAsyncReturnType } from "@trpc/server";
+import { auth } from "@/auth";
+
+export type CreateContextOptions = {
+  req: Request;
+};
+
+export async function createTRPCContext(_opts: CreateContextOptions) {
+  const session = await auth();
+  const accessToken = (session as any)?.accessToken as string | undefined;
+  const provider = (session as any)?.provider as string | undefined;
+  return { session, accessToken, provider };
+}
+
+export type TRPCContext = inferAsyncReturnType<typeof createTRPCContext>;
+
+

--- a/server/trpc/procedures.ts
+++ b/server/trpc/procedures.ts
@@ -1,0 +1,78 @@
+import { z } from "zod";
+import { publicProcedure, router } from "./router";
+import { mcp } from "@/server/mcp";
+import { jobManager } from "@/server/jobs/jobManager";
+import { runOrchestration } from "@/server/orchestrator/orchestrator";
+import type { TRPCContext } from "./context";
+
+export const taskRouter = router({
+  startFigmaTask: publicProcedure
+    .input(
+      z.object({
+        prompt: z.string(),
+        fileId: z.string(),
+      })
+    )
+    .mutation(async ({ input, ctx }) => {
+      const { accessToken } = ctx as TRPCContext & { accessToken?: string };
+      const jobId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      jobManager.create(jobId);
+
+      // Fire and forget
+      (async () => {
+        try {
+          jobManager.setStatus(jobId, "running");
+          await runOrchestration({ taskId: jobId, prompt: input.prompt, fileId: input.fileId, platform: "figma", accessToken });
+        } catch (err) {
+          jobManager.setStatus(jobId, "failed", { error: (err as Error).message });
+        }
+      })();
+
+      return { jobId };
+    }),
+  generateDesign: publicProcedure
+    .input(
+      z.object({
+        prompt: z.string(),
+        fileId: z.string(),
+        platform: z.enum(["figma", "framer", "canva"]).default("figma"),
+      })
+    )
+    .mutation(async ({ input, ctx }) => {
+      const { accessToken } = ctx as TRPCContext & { accessToken?: string };
+      const jobId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      jobManager.create(jobId);
+
+      (async () => {
+        try {
+          jobManager.setStatus(jobId, "running", { result: { message: "Planning..." } });
+          await runOrchestration({
+            taskId: jobId,
+            prompt: input.prompt,
+            fileId: input.fileId,
+            platform: input.platform,
+            accessToken,
+          });
+        } catch (err) {
+          jobManager.setStatus(jobId, "failed", { error: (err as Error).message });
+        }
+      })();
+
+      return { jobId };
+    }),
+
+  getJobStatus: publicProcedure
+    .input(z.object({ jobId: z.string() }))
+    .query(({ input }) => {
+      const job = jobManager.get(input.jobId);
+      if (!job) return { status: "not_found" as const };
+      return job;
+    }),
+
+  listJobs: publicProcedure.query(() => {
+    // Not persisted; placeholder could be enhanced later
+    return { message: "Listing not persisted in-memory" };
+  }),
+});
+
+

--- a/server/trpc/router.ts
+++ b/server/trpc/router.ts
@@ -1,0 +1,17 @@
+import { initTRPC } from "@trpc/server";
+import type { TRPCContext } from "./context";
+import { taskRouter } from "./procedures";
+
+const t = initTRPC.context<TRPCContext>().create();
+
+export const router = t.router;
+export const publicProcedure = t.procedure;
+
+export const appRouter = router({
+  health: publicProcedure.query(() => ({ ok: true })),
+  task: taskRouter,
+});
+
+export type AppRouter = typeof appRouter;
+
+


### PR DESCRIPTION
- [x] setup an unified MCP Server for interacting with design platforms 
- [x] oauth for figma via nextAuth
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Introduces a unified MCP server to run design tasks across Figma, Framer, and Canva, with an orchestrator and job status tracking via tRPC. Adds Figma OAuth via NextAuth and endpoints to start tasks and check progress.

- **New Features**
  - UnifiedMCPServer with registered providers for Figma, Framer, and Canva.
  - Orchestrator that plans steps, executes actions via MCP, and updates progress through an in-memory JobManager.
  - tRPC context wired to NextAuth; passes accessToken to platform providers.
  - tRPC endpoints: startFigmaTask, generateDesign (multi-platform), getJobStatus, and health.

- **Migration**
  - Configure NextAuth Figma OAuth to populate session.accessToken.
  - Use task.generateDesign or task.startFigmaTask with prompt and fileId; poll getJobStatus for progress.
  - Providers are stubs; integrate real platform APIs where needed.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Unified workflow to run design tasks across Figma, Framer, and Canva.
  - Kick off design generation from a prompt and file, returning a job ID and running in the background.
  - Live job tracking with statuses: queued, running, completed, failed.
  - Orchestrated, step-by-step execution with a final summary.
  - Health check endpoint for service availability.

- API
  - Endpoints to start platform-specific or generic design tasks, retrieve job status by ID, and list jobs.
  - Supports passing access tokens from authenticated sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->